### PR TITLE
Bug: Allow no reducers to be passed to score_async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Human agent: Enable installation even when default tool user is not root.
 - Hooks: Propagate LimitExceededError so that hooks can raise limit errors.
 - Bugfix: Fix Google Gemini 2.5 function calling configuration error when using native search tools.
+- Bugfix: Enable passing no reducers to `async_score` in eval score.
 
 
 ## 0.3.132 (12 September 2025)

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -253,7 +253,7 @@ async def score_async(
 
         # override epochs_reducer if specified
         epochs_reducer = create_reducers(epochs_reducer)
-        if epochs_reducer:
+        if epochs_reducer is not None:
             log.eval.config.epochs_reducer = reducer_log_names(epochs_reducer)
         else:
             epochs_reducer = reducers_from_log_header(log)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? 

If you pass `epochs_reducer=[]` to score_async, the log's reducer is used.

### What is the new behavior?

If you pass `epochs_reducer=[]` to score_async, then no reducers are used.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Only if people were relying on this behaviour for `epochs_reducer=[]`. In this case they can use `None` instead.